### PR TITLE
Add light/dark mode toggle and Inter font for v2

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,27 @@ import CompactView from './components/CompactView';
 function App() {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
   const [viewMode, setViewMode] = useState('v2'); // 'v1' or 'v2'
+  const [theme, setTheme] = useState(() => {
+    // Get theme from localStorage or default to 'light'
+    return localStorage.getItem('theme') || 'light';
+  });
+
+  useEffect(() => {
+    // Force dark mode when viewing v1
+    if (viewMode === 'v1') {
+      document.documentElement.setAttribute('data-theme', 'dark');
+      document.body.style.backgroundColor = '#000000';
+    } else {
+      // Apply theme normally for v2
+      document.documentElement.setAttribute('data-theme', theme);
+      localStorage.setItem('theme', theme);
+      document.body.style.backgroundColor = theme === 'dark' ? '#000000' : '#ffffff';
+    }
+  }, [theme, viewMode]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => prevTheme === 'dark' ? 'light' : 'dark');
+  };
 
   useEffect(() => {
     const handleResize = () => {
@@ -89,6 +110,12 @@ function App() {
                   v1
                 </button>
               </div>
+
+              {viewMode === 'v2' && (
+                <button className="theme-toggle-btn" onClick={toggleTheme}>
+                  {theme === 'dark' ? 'Light' : 'Dark'}
+                </button>
+              )}
 
               {viewMode === 'v1' ? (
                 <>

--- a/src/App.scss
+++ b/src/App.scss
@@ -5,7 +5,7 @@
 // Variables
 // ==========================================
 :root {
-  // Colors
+  // Colors - Dark Mode (default)
   --color-background: #000000;
   --color-text: rgba(255, 255, 255, 0.87);
   --color-text-muted: #bababa;
@@ -37,6 +37,27 @@
   --transition-normal: 0.3s ease;
 }
 
+// Light Mode
+[data-theme='light'] {
+  --color-background: #ffffff;
+  --color-text: rgba(0, 0, 0, 0.87);
+  --color-text-muted: #666666;
+  --color-accent-primary: #0066cc;
+  --color-accent-secondary: #4d4dff;
+  --color-accent-tertiary: #000000;
+  --color-border: #e0e0e0;
+  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.08);
+  --shadow-lg: 0px 8px 16px rgba(0,0,0,0.1);
+}
+
+* {
+  transition: background-color var(--transition-normal), color var(--transition-normal);
+}
+
+body {
+  overflow-x: hidden;
+}
+
 // ==========================================
 // Global Styles
 // ==========================================
@@ -45,6 +66,7 @@
   margin: 0 auto;
   padding: 1.5rem;
   text-align: center;
+  overflow-x: hidden;
 }
 
 .home-screen {
@@ -149,6 +171,71 @@
       border-left: 2px solid var(--color-accent-primary);
       border-top: 2px solid var(--color-accent-primary);
     }
+  }
+}
+
+// ==========================================
+// Theme Toggle Button
+// ==========================================
+.theme-toggle-btn {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  z-index: 1000;
+  padding: 6px 16px;
+  background-color: transparent;
+  border: none;
+  font-size: 0.85rem;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 1.2px;
+  color: var(--color-text);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  outline: none;
+  text-transform: uppercase;
+  
+  // Corner borders
+  &:before,
+  &:after {
+    content: '';
+    position: absolute;
+    width: 15px;
+    height: 15px;
+    border: 2px solid var(--color-text-muted);
+    transition: all var(--transition-normal);
+  }
+  
+  // Top-left corner
+  &:before {
+    top: 0;
+    left: 0;
+    border-right: none;
+    border-bottom: none;
+  }
+  
+  // Bottom-right corner
+  &:after {
+    bottom: 0;
+    right: 0;
+    border-left: none;
+    border-top: none;
+  }
+  
+  &:hover {
+    color: var(--color-accent-primary);
+    
+    &:before,
+    &:after {
+      border-color: var(--color-accent-primary);
+      width: 20px;
+      height: 20px;
+    }
+  }
+  
+  &:focus,
+  &:focus-visible {
+    outline: none;
+    box-shadow: none;
   }
 }
 

--- a/src/components/CompactView.jsx
+++ b/src/components/CompactView.jsx
@@ -6,6 +6,7 @@ const CompactView = () => {
     <div className="compact-view">
       <div className="compact-intro">
         <h1>I'm Eric Ly.</h1>
+        <br />
         <p>CS & Econ @ CSUF. Passionate in AI systems.</p>
         <br />
         <p>
@@ -50,8 +51,6 @@ const CompactView = () => {
         </p>
         <br />
       </div>
-
-
 
     </div>
   );

--- a/src/components/CompactView.scss
+++ b/src/components/CompactView.scss
@@ -3,6 +3,9 @@
   width: 100%;
   max-width: 700px;
   padding: 4rem 0rem 2rem 0rem;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  overflow-x: hidden;
 }
 
 .compact-intro {
@@ -22,6 +25,7 @@
     letter-spacing: 0.3px;
     color: var(--color-text);
     line-height: 1.6;
+    font-family: 'Inter', system-ui, sans-serif;
     
     i, em {
       font-style: italic !important;
@@ -42,6 +46,7 @@
       letter-spacing: 0.3px;
       color: var(--color-text);
       line-height: 1.6;
+      font-family: 'Inter', system-ui, sans-serif;
       
       a {
         color: var(--color-text);
@@ -95,4 +100,7 @@
     }
   }
 }
+
+// Import Inter font
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
 

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -37,7 +37,7 @@ if (isFirebaseConfigured) {
 // Helper function to log events (no-op if Firebase not configured)
 export const logAnalyticsEvent = (eventName, eventParams = {}) => {
   if (analytics) {
-    logEvent(analytics, eventName, eventParams);
+  logEvent(analytics, eventName, eventParams);
   }
 };
 


### PR DESCRIPTION
- Added theme toggle button with corner borders (v2 only)
- v2 defaults to light mode with white background
- v1 always stays in dark mode (unchanged)
- Applied Inter font to v2 content
- Fixed horizontal overflow issues
- Theme preference saved in localStorage
- Toggle shows 'LIGHT'/'DARK' text with hover effects